### PR TITLE
Implement `from_sorted_iter()` and `compute_hash_from_sorted_iter()` (initial version).

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ mod nibble;
 mod node;
 mod nodes;
 mod storage;
+mod util;
 
 /// Patricia Merkle Tree implementation.
 #[derive(Clone, Debug, Default)]
@@ -153,6 +154,19 @@ where
 
             &self.hash.1
         }
+    }
+
+    /// Compute the root hash of a tree given a sorted iterator to its items.
+    ///
+    /// Panics if the iterator is not sorted.
+    pub fn compute_hash_from_sorted_iter<'a>(
+        iter: impl IntoIterator<Item = (&'a P, &'a V)>,
+    ) -> Output<H>
+    where
+        P: 'a,
+        V: 'a,
+    {
+        util::compute_hash_from_sorted_iter::<P, V, H>(iter)
     }
 
     /// Calculate approximated memory usage (both used and allocated).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,18 @@ where
         }
     }
 
+    /// Generate a tree from a sorted items iterator.
+    ///
+    /// Panics if the iterator is not sorted.
+    pub fn from_sorted_iter(iter: impl IntoIterator<Item = (P, V)>) -> Self {
+        let mut tree = Self::new();
+        for (path, value) in iter {
+            tree.insert(path, value);
+        }
+
+        tree
+    }
+
     /// Compute the root hash of a tree given a sorted iterator to its items.
     ///
     /// Panics if the iterator is not sorted.
@@ -163,8 +175,8 @@ where
         iter: impl IntoIterator<Item = (&'a P, &'a V)>,
     ) -> Output<H>
     where
-        P: 'a,
-        V: 'a,
+        P: 'a + Clone,
+        V: 'a + Clone,
     {
         util::compute_hash_from_sorted_iter::<P, V, H>(iter)
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,125 +1,74 @@
-#![warn(warnings)]
-
-use crate::nibble::Nibble;
+use crate::PatriciaMerkleTree;
 use digest::{Digest, Output};
 
 pub fn compute_hash_from_sorted_iter<'a, P, V, H>(
     iter: impl IntoIterator<Item = (&'a P, &'a V)>,
 ) -> Output<H>
 where
-    P: 'a + AsRef<[u8]>,
-    V: 'a + AsRef<[u8]>,
+    P: 'a + AsRef<[u8]> + Clone,
+    V: 'a + AsRef<[u8]> + Clone,
     H: Digest,
 {
-    let iter = iter.into_iter();
-
-    let mut nodes_stack: Vec<StackItem<H>> = Vec::new();
-    let mut actual_path: (&[u8], Option<Nibble>) = (b"", None);
-    let mut nodes_count: usize = 0;
+    let mut tree = PatriciaMerkleTree::<P, V, H>::new();
 
     for (path, value) in iter {
-        let path = path.as_ref();
-        let value = value.as_ref();
-
-        if nodes_stack.is_empty() {
-            nodes_stack.push(StackItem::RawNode(path, value));
-            nodes_count += 1;
-
-            actual_path = (
-                &path[..path.len() - 1],
-                path.last().map(|x| Nibble::try_from(x >> 4).unwrap()),
-            );
-        } else {
-            let mut offset = path
-                .iter()
-                .zip(actual_path.0)
-                .take_while(|(a, b)| a == b)
-                .count();
-
-            offset *= 2;
-
-            let actual_path_len = 2 * actual_path.0.len() + actual_path.1.is_some() as usize;
-            if offset + 1 == actual_path_len {
-                if path.get(offset >> 1).map(|x| x >> 4) == actual_path.1.map(u8::from) {
-                    offset += 1;
-                }
-            } else if path.get(offset >> 1).map(|x| x >> 4)
-                == actual_path.0.get(offset >> 1).map(|x| x >> 4)
-            {
-                offset += 1;
-            }
-
-            assert!(
-                path.len() <= (2 * actual_path.0.len() + 1 + actual_path.1.is_some() as usize) >> 1,
-                "iter is not sorted",
-            );
-            // TODO Check sorted values when pushing choices.
-            println!("offset = {offset}, actual_path_len = {actual_path_len}");
-
-            if offset == actual_path_len {
-                if path.get(offset >> 1).is_some() {
-                    nodes_stack.push(StackItem::RawNode(path, value));
-                    nodes_count += 1;
-                } else {
-                    todo!("branch with value")
-                }
-            } else {
-                for node in &nodes_stack[nodes_stack.len() - nodes_count..] {
-                    // TODO: Encode node (replacing the value in the stack).
-                }
-                // TODO: Encode branch (with values from stack).
-                nodes_stack.truncate(nodes_stack.len() - nodes_count);
-                nodes_count = 0;
-
-                if offset + 1 < actual_path_len {
-                    // TODO: Encode extension.
-                    // TODO: Push encoded extension.
-                    println!("extension (prefix len is {})", actual_path_len - offset);
-                }
-            }
-        }
-
-        println!("path = {path:02x?}, actual_path = {actual_path:02x?}");
+        tree.insert(path.clone(), value.clone());
     }
 
-    if nodes_count > 0 {
-        // TODO: Encode branch.
-        // TODO: Maybe encode prefix.
-    }
-
-    // TODO: Keep encoding until the root (somehow...).
-    // TODO: Maybe hash the root.
-
-    todo!()
-}
-
-enum StackItem<'a, H>
-where
-    H: Digest,
-{
-    RawNode(&'a [u8], &'a [u8]),
-    NodeRef(Output<H>, usize),
+    tree.compute_hash().clone()
 }
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use hex_literal::hex;
+    use crate::PatriciaMerkleTree;
+    use proptest::{
+        collection::{btree_set, vec},
+        prelude::*,
+    };
     use sha3::Keccak256;
+    use std::sync::Arc;
 
-    #[test]
-    fn test() {
-        const DATA: &[(&[u8], &[u8])] = &[
-            (&hex!("0123"), &hex!("0123")),
-            (&hex!("0124"), &hex!("0124")),
-            (&hex!("0246"), &hex!("0246")),
-            // (&hex!("1234"), &hex!("1234")),
-        ];
+    proptest! {
+        #[test]
+        fn proptest_compare_hashes_simple(path in vec(any::<u8>(), 1..32), value in vec(any::<u8>(), 1..100)) {
+            expect_hash(vec![(path, value)])?;
+        }
 
-        compute_hash_from_sorted_iter::<&[u8], &[u8], Keccak256>(
-            DATA //
-                .iter()
-                .map(|(a, b)| (a, b)),
+        #[test]
+        fn proptest_compare_hashes_multiple(data in btree_set((vec(any::<u8>(), 1..32), vec(any::<u8>(), 1..100)), 1..100)) {
+            expect_hash(data.into_iter().collect())?;
+        }
+    }
+
+    fn expect_hash(data: Vec<(Vec<u8>, Vec<u8>)>) -> Result<(), TestCaseError> {
+        prop_assert_eq!(
+            compute_hash_cita_trie(data.clone()),
+            compute_hash_ours(data)
         );
+        Ok(())
+    }
+
+    fn compute_hash_ours(data: Vec<(Vec<u8>, Vec<u8>)>) -> Vec<u8> {
+        PatriciaMerkleTree::<_, _, Keccak256>::compute_hash_from_sorted_iter(
+            data.iter().map(|(a, b)| (a, b)),
+        )
+        .to_vec()
+    }
+
+    fn compute_hash_cita_trie(data: Vec<(Vec<u8>, Vec<u8>)>) -> Vec<u8> {
+        use cita_trie::MemoryDB;
+        use cita_trie::{PatriciaTrie, Trie};
+        use hasher::HasherKeccak;
+
+        let memdb = Arc::new(MemoryDB::new(true));
+        let hasher = Arc::new(HasherKeccak::new());
+
+        let mut trie = PatriciaTrie::new(Arc::clone(&memdb), Arc::clone(&hasher));
+
+        for (key, value) in data {
+            trie.insert(key.to_vec(), value.to_vec()).unwrap();
+        }
+
+        trie.root().unwrap()
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,125 @@
+#![warn(warnings)]
+
+use crate::nibble::Nibble;
+use digest::{Digest, Output};
+
+pub fn compute_hash_from_sorted_iter<'a, P, V, H>(
+    iter: impl IntoIterator<Item = (&'a P, &'a V)>,
+) -> Output<H>
+where
+    P: 'a + AsRef<[u8]>,
+    V: 'a + AsRef<[u8]>,
+    H: Digest,
+{
+    let iter = iter.into_iter();
+
+    let mut nodes_stack: Vec<StackItem<H>> = Vec::new();
+    let mut actual_path: (&[u8], Option<Nibble>) = (b"", None);
+    let mut nodes_count: usize = 0;
+
+    for (path, value) in iter {
+        let path = path.as_ref();
+        let value = value.as_ref();
+
+        if nodes_stack.is_empty() {
+            nodes_stack.push(StackItem::RawNode(path, value));
+            nodes_count += 1;
+
+            actual_path = (
+                &path[..path.len() - 1],
+                path.last().map(|x| Nibble::try_from(x >> 4).unwrap()),
+            );
+        } else {
+            let mut offset = path
+                .iter()
+                .zip(actual_path.0)
+                .take_while(|(a, b)| a == b)
+                .count();
+
+            offset *= 2;
+
+            let actual_path_len = 2 * actual_path.0.len() + actual_path.1.is_some() as usize;
+            if offset + 1 == actual_path_len {
+                if path.get(offset >> 1).map(|x| x >> 4) == actual_path.1.map(u8::from) {
+                    offset += 1;
+                }
+            } else if path.get(offset >> 1).map(|x| x >> 4)
+                == actual_path.0.get(offset >> 1).map(|x| x >> 4)
+            {
+                offset += 1;
+            }
+
+            assert!(
+                path.len() <= (2 * actual_path.0.len() + 1 + actual_path.1.is_some() as usize) >> 1,
+                "iter is not sorted",
+            );
+            // TODO Check sorted values when pushing choices.
+            println!("offset = {offset}, actual_path_len = {actual_path_len}");
+
+            if offset == actual_path_len {
+                if path.get(offset >> 1).is_some() {
+                    nodes_stack.push(StackItem::RawNode(path, value));
+                    nodes_count += 1;
+                } else {
+                    todo!("branch with value")
+                }
+            } else {
+                for node in &nodes_stack[nodes_stack.len() - nodes_count..] {
+                    // TODO: Encode node (replacing the value in the stack).
+                }
+                // TODO: Encode branch (with values from stack).
+                nodes_stack.truncate(nodes_stack.len() - nodes_count);
+                nodes_count = 0;
+
+                if offset + 1 < actual_path_len {
+                    // TODO: Encode extension.
+                    // TODO: Push encoded extension.
+                    println!("extension (prefix len is {})", actual_path_len - offset);
+                }
+            }
+        }
+
+        println!("path = {path:02x?}, actual_path = {actual_path:02x?}");
+    }
+
+    if nodes_count > 0 {
+        // TODO: Encode branch.
+        // TODO: Maybe encode prefix.
+    }
+
+    // TODO: Keep encoding until the root (somehow...).
+    // TODO: Maybe hash the root.
+
+    todo!()
+}
+
+enum StackItem<'a, H>
+where
+    H: Digest,
+{
+    RawNode(&'a [u8], &'a [u8]),
+    NodeRef(Output<H>, usize),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use hex_literal::hex;
+    use sha3::Keccak256;
+
+    #[test]
+    fn test() {
+        const DATA: &[(&[u8], &[u8])] = &[
+            (&hex!("0123"), &hex!("0123")),
+            (&hex!("0124"), &hex!("0124")),
+            (&hex!("0246"), &hex!("0246")),
+            // (&hex!("1234"), &hex!("1234")),
+        ];
+
+        compute_hash_from_sorted_iter::<&[u8], &[u8], Keccak256>(
+            DATA //
+                .iter()
+                .map(|(a, b)| (a, b)),
+        );
+    }
+}


### PR DESCRIPTION
Add functions for:
  - Generating a tree more efficiently from a sorted iterator.
  - Computing the merkle root from a sorted iterator.

This initial version is equivalent (or even potentially worse) to calling `.insert()` manually.

> Note: `.compute_hash_from_sorted_iter()` will not require `Clone` on the path and value, but it's necessary right now to keep the same signature (`impl IntoIterator<(&P, &V)>`).